### PR TITLE
There's a cert error with https for install.libki.org, so at the mome…

### DIFF
--- a/installation.adoc
+++ b/installation.adoc
@@ -6,7 +6,7 @@ Do you want to setup Libki as fast as possible and have a dedicated server? Then
 
 [source,bash]
 ----
-wget -O- https://install.libki.org | bash
+wget -O- install.libki.org | bash
 ----
 
 (By the way, that's the letter O, not the number 0.)


### PR DESCRIPTION
…nt the installer uses http instead. It's shorter, so I might stick with it anyway.